### PR TITLE
Enable domains or entities to be excluded from publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Publish HASS events to your [Elasticsearch](https://elastic.co) cluster!
 * Automatically maintains Indexes and Index Templates using the Rollover API
 * Supports [X-Pack Security](https://www.elastic.co/products/x-pack/security) via optional username and password
 * Tracks the Elasticsearch cluster health in the `sensor.es_cluster_health` sensor
+* Exclude specific entities or groups from publishing
 
 ## Compatability
 * Elasticsearch 6.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
@@ -33,7 +34,7 @@ This is the bare-minimum configuration you need to get up-and-running:
 ```yaml
 elastic:
     # URL should point to your Elasticsearch cluster
-    url: http://localost:9200
+    url: http://localhost:9200
 ```
 ### Configuration Variables
 All variables are optional unless marked required.
@@ -41,6 +42,9 @@ All variables are optional unless marked required.
 - **url** (*Required*): The URL of your Elasticsearch cluster
 - **username**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a username here
 - **password**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a password here
+- **exclude**:
+    - **domains**: Specify an optional array of domains to exclude from publishing
+    - **entities**: Specify an optional array of entity ids to exclude from publishing
 #### Advanced Configuration
 - **index_format** (*default:* `"hass-events"`): The format of all index names used by this component. The format specified will be used to derive the actual index names.
 Actual names use the [Rollover API](https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-rollover-index.html) convention of appending a 5-digit number to the end. e.g.: `hass-events-00001`
@@ -52,6 +56,35 @@ Actual names use the [Rollover API](https://www.elastic.co/guide/en/elasticsearc
 - **rollover_docs** (*default:* `100000`): Specifies the `max_docs` condition of the Rollover request
 - **rollover_size** (*default:* `"5gb"`): Specifies the `max_size` condition of the Rollover request
 
+
+### Example Configurations
+**Exclude all groups from publishing:**
+```yaml
+elastic:
+    # URL should point to your Elasticsearch cluster
+    url: http://localhost:9200
+    exclude:
+        domains: ['group']
+```
+
+**Exclude a specific switch from publishing:**
+```yaml
+elastic:
+    # URL should point to your Elasticsearch cluster
+    url: http://localhost:9200
+    exclude:
+        entities: ['switch.living_room_switch']
+```
+
+**Multiple exclusions:**
+```yaml
+elastic:
+    # URL should point to your Elasticsearch cluster
+    url: http://localhost:9200
+    exclude:
+        domains: ['group', 'automation']
+        entities: ['switch.living_room_switch', 'light.hallway_light']
+```
 
 ## Support
 This project is not endorsed or supported by either Elastic or Home-Assistant - please open a GitHub issue for any questions, bugs, or feature requests.

--- a/elastic.py
+++ b/elastic.py
@@ -7,7 +7,9 @@ from datetime import (datetime)
 import asyncio
 import voluptuous as vol
 from homeassistant.const import (
-    CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_ALIAS, EVENT_STATE_CHANGED)
+    CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_ALIAS, EVENT_STATE_CHANGED,
+    CONF_EXCLUDE, CONF_DOMAINS, CONF_ENTITIES
+)
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import (
     state as state_helper,
@@ -48,7 +50,11 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Optional(CONF_REQUEST_ROLLOVER_FREQUENCY, default=ONE_HOUR): cv.positive_int,
         vol.Optional(CONF_ROLLOVER_AGE, default='60d'): cv.string,
         vol.Optional(CONF_ROLLOVER_DOCS, default=1000000): cv.positive_int,
-        vol.Optional(CONF_ROLLOVER_SIZE, default='5gb'): cv.string
+        vol.Optional(CONF_ROLLOVER_SIZE, default='5gb'): cv.string,
+        vol.Optional(CONF_EXCLUDE, default={}): vol.Schema({
+            vol.Optional(CONF_DOMAINS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_ENTITIES, default=[]): cv.entity_ids
+        })
     }),
 }, extra=vol.ALLOW_EXTRA)
 
@@ -141,8 +147,19 @@ class DocumentPublisher: # pylint: disable=unused-variable
         self._hass = hass
         self._index_format = config.get(CONF_INDEX_FORMAT)
         self._index_alias = config.get(CONF_ALIAS)
+
         self._publish_frequency = config.get(CONF_PUBLISH_FREQUENCY)
         self._only_publish_changed = config.get(CONF_ONLY_PUBLISH_CHANGED)
+
+        excluded = config.get(CONF_EXCLUDE)
+        self._excluded_domains = excluded.get(CONF_DOMAINS)
+        self._excluded_entities = excluded.get(CONF_ENTITIES)
+
+        if self._excluded_domains:
+            _LOGGER.debug("Excluding the following domains: %s", str(self._excluded_domains))
+
+        if self._excluded_entities:
+            _LOGGER.debug("Excluding the following entities: %s", str(self._excluded_entities))
 
         self._rollover_frequency = config.get(CONF_REQUEST_ROLLOVER_FREQUENCY)
         self._rollover_conditions = {
@@ -166,8 +183,20 @@ class DocumentPublisher: # pylint: disable=unused-variable
         """Returns the last publish time"""
         return self._last_publish_time
 
-    def enqueue_state(self, state):
-        self.publish_queue.put(state)
+    def enqueue_state(self, entry):
+        state = entry['state']
+        domain = state.domain
+        entity_id = state.entity_id
+
+        if domain in self._excluded_domains:
+            _LOGGER.debug("Skipping %s: it belongs to an excluded domain", entity_id)
+            return
+
+        if entity_id in self._excluded_entities:
+            _LOGGER.debug("Skipping %s: this entity is explicitly excluded", entity_id)
+            return
+
+        self.publish_queue.put(entry)
 
     def do_publish(self):
         "Publishes all queued documents to the Elasticsearch cluster"
@@ -194,6 +223,10 @@ class DocumentPublisher: # pylint: disable=unused-variable
         if not self._only_publish_changed:
             all_states = self._hass.states.async_all()
             for state in all_states:
+                if (state.domain in self._excluded_domains
+                        or state.entity_id in self._excluded_entities):
+                    continue
+
                 if state.object_id not in entity_counts:
                     actions.append(self._state_to_bulk_action(state, self._last_publish_time))
 


### PR DESCRIPTION
This PR adds two configuration entries to allow entire domains or specific entities to be excluded from publish to Elasticsearch:

```yml
exclude:
  domains: ['group']
  entities: ['switch.foo']
```