### PR TITLE
Adds configuration for customizing SSL connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ All variables are optional unless marked required.
 - **url** (*Required*): The URL of your Elasticsearch cluster
 - **username**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a username here
 - **password**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a password here
+- **verify_ssl** (*default:* `true`): Set to `false` to disable SSL certificate verification.
+- **ssl_ca_path** (*default:* `None`): Optional path to PEM encoded certificate authority bundle.
 - **exclude**:
     - **domains**: Specify an optional array of domains to exclude from publishing
     - **entities**: Specify an optional array of entity ids to exclude from publishing


### PR DESCRIPTION
This introduces two new optional configuration options to control the behavior of SSL connections:
```yml
elastic:
  verify_ssl: true # set to false to disable SSL certificate verification
  ssl_ca_path: /path/to/ca.crt # fully qualified path to custom pem encoded certificate authority
```
Fixes #33 

@jakommo I tested these configuration options locally, but if you get some time, I'd love to get your input here to make sure I captured your requirements.