### PR TITLE
Update travis requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: python
 python:
   - "3.6"
 install:
-  - pip install -r requirements.txt
+  - pip install -r requirements.travis.txt
 script:
   - pylint custom_components/elastic.py

--- a/requirements.travis.txt
+++ b/requirements.travis.txt
@@ -1,0 +1,4 @@
+elasticsearch>=6.2.0
+pylint==1.8
+pytest==3.5.1
+homeassistant>=0.69.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-elasticsearch==6.2.0
-pylint==1.8
-pytest==3.5.1
-homeassistant==0.69.1


### PR DESCRIPTION
This renames `requirements.txt` => `requirements.travis.txt` to make it clear that these should only be used by travis.

Additionally, the requirements have been updated to be less restrictive with respect to versioning.

Fixes #39 