### PR TITLE
Support ECS 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Publish HASS events to your [Elasticsearch](https://elastic.co) cluster!
 
 ## Compatability
 * Elasticsearch 6.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
+* [Elastic Common Schema version 1.0.0](https://github.com/elastic/ecs/releases/tag/v1.0.0)
 
 ## Getting Started
 The Elasticsearch component requires, well, [Elasticsearch](https://www.elastic.co/products/elasticsearch)!
@@ -34,6 +35,7 @@ Example: `/home/pi/.homeassistant` and `/home/pi/.homeassistant/custom_component
 |-- custom_components/
 |   |-- elastic/
 |       |-- __init__.py
+|       |-- index_mapping.json
 |       |-- sensor.py
 
 ```
@@ -56,6 +58,7 @@ All variables are optional unless marked required.
 - **exclude**:
     - **domains**: Specify an optional array of domains to exclude from publishing
     - **entities**: Specify an optional array of entity ids to exclude from publishing
+- **tags** (*default:* [`hass`]): Specify an array of tags to include in each published document.
 #### Advanced Configuration
 - **verify_ssl** (*default:* `true`): Set to `false` to disable SSL certificate verification.
 - **ssl_ca_path** (*default:* `None`): Optional path to PEM encoded certificate authority bundle.

--- a/custom_components/elastic/index_mapping.json
+++ b/custom_components/elastic/index_mapping.json
@@ -1,0 +1,275 @@
+{
+  "dynamic": "strict",
+  "properties": {
+    "hass": {
+      "type": "object",
+      "properties": {
+        "domain": {
+          "type": "keyword",
+          "ignore_above": 1024
+        },
+        "object_id": {
+          "type": "keyword",
+          "ignore_above": 1024
+        },
+        "entity_id": {
+          "type": "keyword",
+          "ignore_above": 1024
+        },
+        "geo": {
+          "type": "object",
+          "properties": {
+            "location": {
+              "type": "geo_point"
+            }
+          }
+        },
+        "value": {
+          "type": "text",
+          "fields": {
+            "keyword": {
+              "type": "keyword",
+              "ignore_above": 2048
+            },
+            "float": {
+              "type": "float",
+              "ignore_malformed": true
+            }
+          }
+        },
+        "attributes": {
+          "type": "object",
+          "dynamic": true
+        }
+      }
+    },
+    "@timestamp": {
+      "type": "date"
+    },
+    "tags": {
+      "ignore_above": 1024,
+      "type": "keyword"
+    },
+    "agent": {
+      "properties": {
+        "ephemeral_id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "version": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        }
+      }
+    },
+    "host": {
+      "properties": {
+        "architecture": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "geo": {
+          "properties": {
+            "city_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "continent_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "country_iso_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "country_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "location": {
+              "type": "geo_point"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "region_iso_code": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "region_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "hostname": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "ip": {
+          "type": "ip"
+        },
+        "mac": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "name": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "os": {
+          "properties": {
+            "family": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "kernel": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "platform": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "version": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "user": {
+          "properties": {
+            "email": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "full_name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "hash": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "name": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    },
+    "event": {
+      "properties": {
+        "action": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "category": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "created": {
+          "type": "date"
+        },
+        "dataset": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "duration": {
+          "type": "long"
+        },
+        "end": {
+          "type": "date"
+        },
+        "hash": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "id": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "kind": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "module": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "original": {
+          "doc_values": false,
+          "ignore_above": 1024,
+          "index": false,
+          "type": "keyword"
+        },
+        "outcome": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "risk_score": {
+          "type": "float"
+        },
+        "risk_score_norm": {
+          "type": "float"
+        },
+        "severity": {
+          "type": "long"
+        },
+        "start": {
+          "type": "date"
+        },
+        "timezone": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        },
+        "type": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        }
+      }
+    },
+    "ecs": {
+      "properties": {
+        "version": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces initial support for the Elastic Common Schema ("ECS") version 1.0.0.

This does not aim to include all available fields that we deem important at this time, but rather serves as a foundation for adding them in a followup PR.

This PR also externalizes the index mapping to improve readability and maintainability. The ECS definitions are more verbose than our existing ones, so keeping them inline in the source was not going to be a good idea long term.

This mostly follows the conversation in #46 with the exception of the `event` fields, because their usage was since clarified in the ECS documentation.

Closes #46 