### PR TITLE
Convert timestamp to UTC if time zone is missing

### DIFF
--- a/custom_components/elastic/__init__.py
+++ b/custom_components/elastic/__init__.py
@@ -11,6 +11,7 @@ from queue import Queue
 from datetime import (datetime)
 import asyncio
 import voluptuous as vol
+from pytz import utc
 from homeassistant.const import (
     CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_ALIAS, EVENT_STATE_CHANGED,
     CONF_EXCLUDE, CONF_DOMAINS, CONF_ENTITIES, CONF_VERIFY_SSL
@@ -347,13 +348,18 @@ class DocumentPublisher:  # pylint: disable=unused-variable
         except ValueError:
             _state = state.state
 
+        if time.tzinfo is None:
+            time_tz = time.astimezone(utc)
+        else:
+            time_tz = time
+
         document_body = {
             'hass.domain': state.domain,
             'hass.object_id': state.object_id,
             'hass.entity_id': state.entity_id,
             'hass.attributes': dict(state.attributes),
             'hass.value': _state,
-            '@timestamp': time
+            '@timestamp': time_tz
         }
 
         document_body.update(self._static_doc_properties)


### PR DESCRIPTION
Some events in home assistant don't have a timezone information in time_fired and use local timezone, other events use UTC. When events arrive to elasticsearch, it treats all of them as UTC events. As a result, if ha runs in EST timezone device_tracker events are lagging 4-5 hours behind when displayed in kibana.

This commit checks if timezone is present and if it's not, converts the timestamp from local time to UTC.