### PR TITLE
Remove cloud_id configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ elastic:
 ### Configuration Variables
 All variables are optional unless marked required.
 #### Basic Configuration
-- **url** (*Required, unless using `cloud_id`*): The URL of your Elasticsearch cluster
-- **cloud_id**: The [Cloud ID](https://www.elastic.co/guide/en/cloud/saas-release/ec-cloud-id.html) of your Elasticsearch cluster
+- **url** (*Required*): The URL of your Elasticsearch cluster
 - **username**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a username here
 - **password**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a password here
 - **exclude**:

--- a/custom_components/elastic/__init__.py
+++ b/custom_components/elastic/__init__.py
@@ -17,7 +17,7 @@ from .es_index_manager import IndexManager
 from .es_gateway import ElasticsearchGateway
 
 from .const import (
-    DOMAIN, CONF_CLOUD_ID, CONF_PUBLISH_ENABLED, CONF_HEALTH_SENSOR_ENABLED,
+    DOMAIN, CONF_PUBLISH_ENABLED, CONF_HEALTH_SENSOR_ENABLED,
     CONF_INDEX_FORMAT, CONF_PUBLISH_FREQUENCY, ONE_MINUTE, CONF_ONLY_PUBLISH_CHANGED,
     CONF_ILM_ENABLED, CONF_ILM_POLICY_NAME, CONF_ILM_MAX_SIZE, CONF_ILM_DELETE_AFTER,
     CONF_SSL_CA_PATH, CONF_TAGS
@@ -30,33 +30,29 @@ ELASTIC_COMPONENTS = [
 ]
 
 CONFIG_SCHEMA = vol.Schema({
-    DOMAIN: vol.All(
-        vol.Schema({
-            vol.Exclusive(CONF_URL, 'url or cloud_id'): cv.url,
-            vol.Exclusive(CONF_CLOUD_ID, 'url or cloud_id'): cv.string,
-            vol.Optional(CONF_USERNAME): cv.string,
-            vol.Optional(CONF_PASSWORD): cv.string,
-            vol.Optional(CONF_PUBLISH_ENABLED, default=True): cv.boolean,
-            vol.Optional(CONF_HEALTH_SENSOR_ENABLED, default=True): cv.boolean,
-            vol.Optional(CONF_PASSWORD): cv.string,
-            vol.Optional(CONF_INDEX_FORMAT, default='hass-events'): cv.string,
-            vol.Optional(CONF_ALIAS, default='active-hass-index'): cv.string,
-            vol.Optional(CONF_PUBLISH_FREQUENCY, default=ONE_MINUTE): cv.positive_int,
-            vol.Optional(CONF_ONLY_PUBLISH_CHANGED, default=False): cv.boolean,
-            vol.Optional(CONF_ILM_ENABLED, default=True): cv.boolean,
-            vol.Optional(CONF_ILM_POLICY_NAME, default="home-assistant"): cv.string,
-            vol.Optional(CONF_ILM_MAX_SIZE, default='30gb'): cv.string,
-            vol.Optional(CONF_ILM_DELETE_AFTER, default='365d'): cv.string,
-            vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
-            vol.Optional(CONF_SSL_CA_PATH): cv.string,
-            vol.Optional(CONF_TAGS, default=['hass']): vol.All(cv.ensure_list, [cv.string]),
-            vol.Optional(CONF_EXCLUDE, default={}): vol.Schema({
-                vol.Optional(CONF_DOMAINS, default=[]): vol.All(cv.ensure_list, [cv.string]),
-                vol.Optional(CONF_ENTITIES, default=[]): cv.entity_ids
-            })
-        }),
-        cv.has_at_least_one_key(CONF_URL, CONF_CLOUD_ID),
-    )
+    DOMAIN: vol.Schema({
+        vol.Required(CONF_URL): cv.url,
+        vol.Optional(CONF_USERNAME): cv.string,
+        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_PUBLISH_ENABLED, default=True): cv.boolean,
+        vol.Optional(CONF_HEALTH_SENSOR_ENABLED, default=True): cv.boolean,
+        vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_INDEX_FORMAT, default='hass-events'): cv.string,
+        vol.Optional(CONF_ALIAS, default='active-hass-index'): cv.string,
+        vol.Optional(CONF_PUBLISH_FREQUENCY, default=ONE_MINUTE): cv.positive_int,
+        vol.Optional(CONF_ONLY_PUBLISH_CHANGED, default=False): cv.boolean,
+        vol.Optional(CONF_ILM_ENABLED, default=True): cv.boolean,
+        vol.Optional(CONF_ILM_POLICY_NAME, default="home-assistant"): cv.string,
+        vol.Optional(CONF_ILM_MAX_SIZE, default='30gb'): cv.string,
+        vol.Optional(CONF_ILM_DELETE_AFTER, default='365d'): cv.string,
+        vol.Optional(CONF_VERIFY_SSL, default=True): cv.boolean,
+        vol.Optional(CONF_SSL_CA_PATH): cv.string,
+        vol.Optional(CONF_TAGS, default=['hass']): vol.All(cv.ensure_list, [cv.string]),
+        vol.Optional(CONF_EXCLUDE, default={}): vol.Schema({
+            vol.Optional(CONF_DOMAINS, default=[]): vol.All(cv.ensure_list, [cv.string]),
+            vol.Optional(CONF_ENTITIES, default=[]): cv.entity_ids
+        })
+    }),
 }, extra=vol.ALLOW_EXTRA)
 
 

--- a/custom_components/elastic/const.py
+++ b/custom_components/elastic/const.py
@@ -12,7 +12,6 @@ CONF_ILM_POLICY_NAME = 'ilm_policy_name'
 CONF_ILM_MAX_SIZE = 'ilm_max_size'
 CONF_ILM_DELETE_AFTER = 'ilm_delete_after'
 CONF_SSL_CA_PATH = 'ssl_ca_path'
-CONF_CLOUD_ID = 'cloud_id'
 
 CONF_TAGS = 'tags'
 

--- a/custom_components/elastic/es_gateway.py
+++ b/custom_components/elastic/es_gateway.py
@@ -1,10 +1,8 @@
 """Encapsulates Elasticsearch operations"""
-import base64
-import binascii
 from homeassistant.const import (
     CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL
 )
-from .const import (CONF_CLOUD_ID, CONF_SSL_CA_PATH)
+from .const import (CONF_SSL_CA_PATH)
 from .es_version import ElasticsearchVersion
 from .es_serializer import get_serializer
 from .logger import LOGGER
@@ -19,12 +17,8 @@ class ElasticsearchGateway:
         self._url = config.get(CONF_URL)
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
-        self._cloud_id = config.get(CONF_CLOUD_ID)
         self._verify_certs = config.get(CONF_VERIFY_SSL)
         self._ca_certs = config.get(CONF_SSL_CA_PATH)
-
-        if self._cloud_id:
-            self._url = decode_cloud_id(self._cloud_id)
 
         LOGGER.debug("Creating Elasticsearch client for %s", self._url)
         self.client = self._create_es_client()
@@ -87,50 +81,3 @@ class ElasticsearchGateway:
             verify_certs=self._verify_certs,
             ca_certs=self._ca_certs
         )
-
-
-def decode_cloud_id(cloud_id):
-    """Decodes the cloud id"""
-
-    # Logic adapted from https://github.com/elastic/beats/blob/6.5/libbeat/cloudid/cloudid.go
-
-    this_cloud_id = cloud_id
-
-    # 1. Ignore anything before `:`
-    idx = this_cloud_id.rfind(':')
-    if idx >= 0:
-        this_cloud_id = this_cloud_id[idx+1:]
-
-    # 2. base64 decode
-    try:
-        this_cloud_id = base64.b64decode(this_cloud_id).decode('utf-8')
-    except binascii.Error:
-        raise Exception(
-            "Invalid cloud_id. Error base64 decoding {}".format(cloud_id))
-
-    # 3. separate based on `$`
-    words = this_cloud_id.split("$")
-    if len(words) < 3:
-        raise Exception(
-            "Invalid cloud_id: expected at least 3 parts in {}".format(cloud_id))
-
-    # 4. extract port from the ES host, or use 443 as the default
-    host, port = extract_port_from_name(words[0], 443)
-    es_id, es_port = extract_port_from_name(words[1], port)
-
-    # 5. form the URLs
-    es_url = "https://{}.{}:{}".format(es_id, host, es_port)
-
-    return es_url
-
-
-def extract_port_from_name(name, default_port):
-    """
-    extractPortFromName takes a string in the form `id:port` and returns the ID and the port
-    If there's no `:`, the default port is returned
-    """
-    idx = name.rfind(":")
-    if idx >= 0:
-        return name[:idx], name[idx+1:]
-
-    return name, default_port


### PR DESCRIPTION
**Breaking Change**

Removes `cloud_id` as a valid configuration option. Elastic Cloud users should instead use the `url` option.

Resolves #86 