### PR TITLE
Upgrade ES Client to 7.9.1; Drops support for 6.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Publish HASS events to your [Elasticsearch](https://elastic.co) cluster!
 * Exclude specific entities or groups from publishing
 
 ## Compatability
-* Elasticsearch 6.7, 6.8, & 7.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
+* Elasticsearch 7.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
 * [Elastic Common Schema version 1.0.0](https://github.com/elastic/ecs/releases/tag/v1.0.0)
 * [Home Assistant Community Store](https://github.com/custom-components/hacs)
 

--- a/custom_components/elastic/es_gateway.py
+++ b/custom_components/elastic/es_gateway.py
@@ -47,8 +47,7 @@ class ElasticsearchGateway:
 
     def _create_es_client(self, sync=False):
         """Constructs an instance of the Elasticsearch client"""
-        from elasticsearch_async import AsyncElasticsearch
-        from elasticsearch import Elasticsearch
+        from elasticsearch import AsyncElasticsearch, Elasticsearch
 
         use_basic_auth = self._username is not None and self._password is not None
 

--- a/custom_components/elastic/manifest.json
+++ b/custom_components/elastic/manifest.json
@@ -7,7 +7,6 @@
     "@legrego"
   ],
   "requirements": [
-    "elasticsearch==6.3.1",
-    "elasticsearch_async==6.2.0"
+    "elasticsearch==7.9.1"
   ]
 }

--- a/info.md
+++ b/info.md
@@ -6,7 +6,7 @@
 * Exclude specific entities or groups from publishing
 
 ## Compatability
-* Elasticsearch 6.x & 7.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
+* Elasticsearch 7.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
 * [Elastic Common Schema version 1.0.0](https://github.com/elastic/ecs/releases/tag/v1.0.0)
 
 ## Getting Started

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-elasticsearch>=6.2.0
-elasticsearch_async>=6.2.0
+elasticsearch>=7.9.1
 flake8>=3.8.3
 pytest==3.5.1
 homeassistant>=0.69.1


### PR DESCRIPTION
**Breaking Change**

Upgrades the ES Client to version `7.9.1`, fro `6.3.0`. This change allows us to use the built-in async capabilities of the `elasticsearch` package without having to rely on the additional `elasticsearch-async` package.

Drops support for versions < 7.0