### PR TITLE
Add connection timeout setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ All variables are optional unless marked required.
 - **url** (*Required*): The URL of your Elasticsearch cluster
 - **username**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a username here
 - **password**: If your cluster is protected with Basic Authentication via [X-Pack Security](https://www.elastic.co/products/x-pack/security), then provide a password here
+- **timeout** (*default:* `30`): Elasticsearch connection timeout (in seconds) for all outbound requests.
 - **exclude**:
     - **domains**: Specify an optional array of domains to exclude from publishing
     - **entities**: Specify an optional array of entity ids to exclude from publishing

--- a/custom_components/elastic/__init__.py
+++ b/custom_components/elastic/__init__.py
@@ -5,7 +5,7 @@ import voluptuous as vol
 
 from homeassistant.const import (
     CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_ALIAS, EVENT_STATE_CHANGED,
-    CONF_EXCLUDE, CONF_DOMAINS, CONF_ENTITIES, CONF_VERIFY_SSL
+    CONF_EXCLUDE, CONF_DOMAINS, CONF_ENTITIES, CONF_VERIFY_SSL, CONF_TIMEOUT
 )
 import homeassistant.helpers.config_validation as cv
 from homeassistant.helpers import (
@@ -34,6 +34,7 @@ CONFIG_SCHEMA = vol.Schema({
         vol.Required(CONF_URL): cv.url,
         vol.Optional(CONF_USERNAME): cv.string,
         vol.Optional(CONF_PASSWORD): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=30): cv.positive_int,
         vol.Optional(CONF_PUBLISH_ENABLED, default=True): cv.boolean,
         vol.Optional(CONF_HEALTH_SENSOR_ENABLED, default=True): cv.boolean,
         vol.Optional(CONF_PASSWORD): cv.string,

--- a/custom_components/elastic/es_gateway.py
+++ b/custom_components/elastic/es_gateway.py
@@ -1,6 +1,6 @@
 """Encapsulates Elasticsearch operations"""
 from homeassistant.const import (
-    CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL
+    CONF_URL, CONF_USERNAME, CONF_PASSWORD, CONF_VERIFY_SSL, CONF_TIMEOUT
 )
 from .const import (CONF_SSL_CA_PATH)
 from .es_version import ElasticsearchVersion
@@ -15,6 +15,7 @@ class ElasticsearchGateway:
         """Initialize the gateway"""
         self._hass = hass
         self._url = config.get(CONF_URL)
+        self._timeout = config.get(CONF_TIMEOUT)
         self._username = config.get(CONF_USERNAME)
         self._password = config.get(CONF_PASSWORD)
         self._verify_certs = config.get(CONF_VERIFY_SSL)
@@ -60,23 +61,27 @@ class ElasticsearchGateway:
                 http_auth=auth,
                 serializer=serializer,
                 verify_certs=self._verify_certs,
-                ca_certs=self._ca_certs
+                ca_certs=self._ca_certs,
+                timeout=self._timeout
             ) if sync else AsyncElasticsearch(
                 [self._url],
                 http_auth=auth,
                 serializer=serializer,
                 verify_certs=self._verify_certs,
-                ca_certs=self._ca_certs
+                ca_certs=self._ca_certs,
+                timeout=self._timeout
             )
 
         return Elasticsearch(
             [self._url],
             serializer=serializer,
             verify_certs=self._verify_certs,
-            ca_certs=self._ca_certs
+            ca_certs=self._ca_certs,
+            timeout=self._timeout
         ) if sync else AsyncElasticsearch(
             [self._url],
             serializer=serializer,
             verify_certs=self._verify_certs,
-            ca_certs=self._ca_certs
+            ca_certs=self._ca_certs,
+            timeout=self._timeout
         )


### PR DESCRIPTION
Adds a new `timeout` setting to allow for custom request timeouts.

Defaults to 30 seconds.