### PR TITLE
Add version to manifest

### DIFF
--- a/custom_components/elasticsearch/manifest.json
+++ b/custom_components/elasticsearch/manifest.json
@@ -1,6 +1,7 @@
 {
   "domain": "elasticsearch",
   "name": "Elasticsearch",
+  "version": "0.4.0",
   "documentation": "https://github.com/legrego/homeassistant-elasticsearch",
   "issue_tracker": "https://github.com/legrego/homeassistant-elasticsearch/issues",
   "dependencies": [],


### PR DESCRIPTION
Adds newly required `version` property to the manifest. See https://developers.home-assistant.io/blog/2021/01/29/custom-integration-changes#versions