### PR TITLE
Require Elasticsearch 7.11+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Publish HASS events to your [Elasticsearch](https://elastic.co) cluster!
 
 ## Compatibility
 
-- Elasticsearch 7.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
+- Elasticsearch 7.11+ (Self or [Cloud](https://www.elastic.co/cloud) hosted). [Version `0.4.0`](https://github.com/legrego/homeassistant-elasticsearch/releases/tag/v0.4.0) includes support for older versions of Elasticsearch.
 - [Elastic Common Schema version 1.0.0](https://github.com/elastic/ecs/releases/tag/v1.0.0)
 - [Home Assistant Community Store](https://github.com/custom-components/hacs)
 

--- a/custom_components/elasticsearch/config_flow.py
+++ b/custom_components/elasticsearch/config_flow.py
@@ -35,6 +35,7 @@ from .errors import (
     AuthenticationRequired,
     CannotConnect,
     InsufficientPrivileges,
+    UnsupportedVersion,
     UntrustedCertificate,
 )
 from .es_gateway import ElasticsearchGateway
@@ -202,6 +203,8 @@ class ElasticFlowHandler(config_entries.ConfigFlow, domain=ELASTIC_DOMAIN):
             errors["base"] = "insufficient_privileges"
         except CannotConnect:
             errors["base"] = "cannot_connect"
+        except UnsupportedVersion:
+            errors["base"] = "unsupported_version"
         except Exception as ex:  # pylint: disable=broad-except
             LOGGER.error(
                 "Unknown error connecting with Elasticsearch cluster. %s",

--- a/custom_components/elasticsearch/errors.py
+++ b/custom_components/elasticsearch/errors.py
@@ -24,3 +24,7 @@ class CannotConnect(ElasticException):
 
 class UntrustedCertificate(ElasticException):
     """Connected with untrusted certificate."""
+
+
+class UnsupportedVersion(ElasticException):
+    """Connected to an unsupported version of Elasticsearch."""

--- a/custom_components/elasticsearch/es_doc_publisher.py
+++ b/custom_components/elasticsearch/es_doc_publisher.py
@@ -287,14 +287,6 @@ class DocumentPublisher:
                 "lon": document_body["hass.attributes"]["longitude"],
             }
 
-        es_version = self._gateway.es_version
-        if es_version.major == 6:
-            return {
-                "_op_type": "index",
-                "_index": self._index_alias,
-                "_type": "doc",
-                "_source": document_body,
-            }
         return {
             "_op_type": "index",
             "_index": self._index_alias,

--- a/custom_components/elasticsearch/es_integration.py
+++ b/custom_components/elasticsearch/es_integration.py
@@ -5,6 +5,7 @@ Support for sending event data to an Elasticsearch cluster
 import asyncio
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .es_doc_publisher import DocumentPublisher

--- a/custom_components/elasticsearch/es_integration.py
+++ b/custom_components/elasticsearch/es_integration.py
@@ -5,7 +5,6 @@ Support for sending event data to an Elasticsearch cluster
 import asyncio
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.typing import HomeAssistantType
 
 from .es_doc_publisher import DocumentPublisher

--- a/custom_components/elasticsearch/es_version.py
+++ b/custom_components/elasticsearch/es_version.py
@@ -1,8 +1,8 @@
-"""Maintains information about the verion of Elasticsearch"""
+"""Maintains information about the version of Elasticsearch"""
 
 
 class ElasticsearchVersion:
-    """Maintains information about the verion of Elasticsearch"""
+    """Maintains information about the version of Elasticsearch"""
 
     def __init__(self, client):
         self._client = client

--- a/custom_components/elasticsearch/es_version.py
+++ b/custom_components/elasticsearch/es_version.py
@@ -1,7 +1,5 @@
 """Maintains information about the verion of Elasticsearch"""
 
-from .logger import LOGGER
-
 
 class ElasticsearchVersion:
     """Maintains information about the verion of Elasticsearch"""
@@ -22,26 +20,9 @@ class ElasticsearchVersion:
         self.minor = int(version_number_parts[1])
         self.build_flavor = version["build_flavor"]
 
-        if self.is_oss_distribution():
-            LOGGER.warning(
-                "\
-                Support for the Elasticseach's OSS distribution is deprecated, \
-                and will not work in a future release. \
-                Download the default distribution from https://elastic.co/downloads \
-            "
-            )
-
     def is_supported_version(self):
         """Determines if this version of ES is supported by this component"""
-        return self.major == 7
-
-    def is_oss_distribution(self):
-        """Determines if this is the OSS distribution"""
-        return self.build_flavor == "oss"
-
-    def is_default_distribution(self):
-        """Determines if this is the default distribution"""
-        return self.build_flavor == "default"
+        return self.major == 7 and self.minor >= 11
 
     def to_string(self):
         """Returns a string representation of the current ES version"""

--- a/custom_components/elasticsearch/manifest.json
+++ b/custom_components/elasticsearch/manifest.json
@@ -10,7 +10,7 @@
   ],
   "config_flow": true,
   "requirements": [
-    "elasticsearch==7.9.1"
+    "elasticsearch==7.11.0"
   ],
   "iot_class": "cloud_polling"
 }

--- a/custom_components/elasticsearch/strings.json
+++ b/custom_components/elasticsearch/strings.json
@@ -23,7 +23,8 @@
             "insufficient_privileges": "[%key:common::config_flow::error::insufficient_privileges%]",
             "missing_credentials": "[%key:common::config_flow::error::missing_credentials%]",
             "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-            "untrusted_connection": "[%key:common::config_flow::error::untrusted_connection%]"
+            "untrusted_connection": "[%key:common::config_flow::error::untrusted_connection%]",
+            "unsupported_version": "[%key:common::config_flow::error::unsupported_version%]"
         },
         "abort": {
             "single_instance_allowed": "[%key:common::config_flow::abort::single_instance_allowed%]",

--- a/custom_components/elasticsearch/translations/en.json
+++ b/custom_components/elasticsearch/translations/en.json
@@ -10,7 +10,8 @@
             "invalid_auth": "Invalid username or password.",
             "insufficient_privileges": "Insufficient privileges for specified user.",
             "missing_credentials": "This cluster requires authentication. Please provide a username and password.",
-            "untrusted_connection": "Elasticsearch's server certificate could not be verified. Either disable TLS verification, or specify a custom CA path below."
+            "untrusted_connection": "Elasticsearch's server certificate could not be verified. Either disable TLS verification, or specify a custom CA path below.",
+            "unsupported_version": "Unsupported version of Elastcsearch detected. The minimum supported version is 7.11.0."
         },
         "step": {
             "user": {

--- a/info.md
+++ b/info.md
@@ -8,7 +8,7 @@
 
 ## Compatibility
 
-- Elasticsearch 7.x (Self or [Cloud](https://www.elastic.co/cloud) hosted), with or without [X-Pack](https://www.elastic.co/products/x-pack).
+- Elasticsearch 7.11+ (Self or [Cloud](https://www.elastic.co/cloud) hosted). [Version `0.4.0`](https://github.com/legrego/homeassistant-elasticsearch/releases/tag/v0.4.0) includes support for older versions of Elasticsearch.
 - [Elastic Common Schema version 1.0.0](https://github.com/elastic/ecs/releases/tag/v1.0.0)
 - [Home Assistant Community Store](https://github.com/custom-components/hacs)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-elasticsearch>=7.9.1
+elasticsearch>=7.11.0
 flake8>=3.8.4
 black>=20.8b1
 isort>=5.6.4

--- a/tests/const.py
+++ b/tests/const.py
@@ -76,12 +76,30 @@ CLUSTER_INFO_MISSING_CREDENTIALS_RESPONSE_BODY = {
     "status": 401,
 }
 
+CLUSTER_INFO_UNSUPPORTED_RESPONSE_BODY = {
+    "name": "775d9437a770",
+    "cluster_name": "home-assistant-cluster",
+    "cluster_uuid": "hz1_5bImTh-45ERkrHS7vg",
+    "version": {
+        "number": "7.10.0",
+        "build_flavor": "default",
+        "build_type": "deb",
+        "build_hash": "1c34507e66d7db1211f66f3513706fdf548736aa",
+        "build_date": "2020-12-05T01:00:33.671820Z",
+        "build_snapshot": False,
+        "lucene_version": "8.7.0",
+        "minimum_wire_compatibility_version": "6.8.0",
+        "minimum_index_compatibility_version": "6.0.0-beta1",
+    },
+    "tagline": "You Know, for Search",
+}
+
 CLUSTER_INFO_RESPONSE_BODY = {
     "name": "775d9437a770",
     "cluster_name": "home-assistant-cluster",
     "cluster_uuid": "hz1_5bImTh-45ERkrHS7vg",
     "version": {
-        "number": "7.10.1",
+        "number": "7.11.0",
         "build_flavor": "default",
         "build_type": "deb",
         "build_hash": "1c34507e66d7db1211f66f3513706fdf548736aa",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -44,6 +44,28 @@ async def test_user_flow_minimum_fields(hass: HomeAssistantType, aioclient_mock)
     assert result["data"]["health_sensor_enabled"] is True
 
 
+async def test_user_flow_unsupported_version(hass: HomeAssistantType, aioclient_mock):
+    """ Test user config flow with minimum fields. """
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+
+    es_url = "http://minimum-fields:9200"
+
+    mock_es_initialization(aioclient_mock, url=es_url, mock_unsupported_version=True)
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], user_input={"url": es_url}
+    )
+
+    assert result["type"] == data_entry_flow.RESULT_TYPE_FORM
+    assert result["step_id"] == "user"
+    assert result["errors"]["base"] == "unsupported_version"
+
+
 async def test_user_flow_to_tls_flow(hass: HomeAssistantType, aioclient_mock):
     """ Test user config flow with config that forces TLS configuration. """
     result = await hass.config_entries.flow.async_init(

--- a/tests/test_util/es_startup_mocks.py
+++ b/tests/test_util/es_startup_mocks.py
@@ -3,6 +3,7 @@ from homeassistant.const import CONF_URL, CONTENT_TYPE_JSON
 from tests.const import (
     CLUSTER_HEALTH_RESPONSE_BODY,
     CLUSTER_INFO_RESPONSE_BODY,
+    CLUSTER_INFO_UNSUPPORTED_RESPONSE_BODY,
     MOCK_COMPLEX_LEGACY_CONFIG,
 )
 
@@ -14,9 +15,14 @@ def mock_es_initialization(
     mock_index_creation=False,
     mock_health_check=False,
     mock_ilm_setup=False,
+    mock_unsupported_version=False,
 ):
 
-    aioclient_mock.get(url, status=200, json=CLUSTER_INFO_RESPONSE_BODY)
+    if mock_unsupported_version:
+        aioclient_mock.get(url, status=200, json=CLUSTER_INFO_UNSUPPORTED_RESPONSE_BODY)
+    else:
+        aioclient_mock.get(url, status=200, json=CLUSTER_INFO_RESPONSE_BODY)
+
     aioclient_mock.post(url + "/_bulk", status=200, json={"items": []})
 
     if mock_template_setup:


### PR DESCRIPTION
Drops support for versions older than `7.11.0`, and simplifies implementation to no longer check to see if certain features are supported.