### PR TITLE
Remove references to build_flavor

### DIFF
--- a/custom_components/elasticsearch/es_version.py
+++ b/custom_components/elasticsearch/es_version.py
@@ -9,7 +9,6 @@ class ElasticsearchVersion:
         self._version_number_str = None
         self.major = None
         self.minor = None
-        self.build_flavor = None
 
     async def async_init(self):
         """I/O bound init"""
@@ -18,7 +17,6 @@ class ElasticsearchVersion:
         self._version_number_str = version["number"]
         self.major = int(version_number_parts[0])
         self.minor = int(version_number_parts[1])
-        self.build_flavor = version["build_flavor"]
 
     def is_supported_version(self):
         """Determines if this version of ES is supported by this component"""

--- a/tests/const.py
+++ b/tests/const.py
@@ -82,7 +82,6 @@ CLUSTER_INFO_UNSUPPORTED_RESPONSE_BODY = {
     "cluster_uuid": "hz1_5bImTh-45ERkrHS7vg",
     "version": {
         "number": "7.10.0",
-        "build_flavor": "default",
         "build_type": "deb",
         "build_hash": "1c34507e66d7db1211f66f3513706fdf548736aa",
         "build_date": "2020-12-05T01:00:33.671820Z",
@@ -100,7 +99,6 @@ CLUSTER_INFO_RESPONSE_BODY = {
     "cluster_uuid": "hz1_5bImTh-45ERkrHS7vg",
     "version": {
         "number": "7.11.0",
-        "build_flavor": "default",
         "build_type": "deb",
         "build_hash": "1c34507e66d7db1211f66f3513706fdf548736aa",
         "build_date": "2020-12-05T01:00:33.671820Z",


### PR DESCRIPTION
Removes references to `version.build_flavor`.
Resolves https://github.com/legrego/homeassistant-elasticsearch/issues/161