### PR TITLE
Do not publish attributes that contain complex values

### DIFF
--- a/custom_components/elasticsearch/es_doc_publisher.py
+++ b/custom_components/elasticsearch/es_doc_publisher.py
@@ -31,6 +31,7 @@ from .const import (
 from .es_serializer import get_serializer
 from .logger import LOGGER
 
+ALLOWED_ATTRIBUTE_TYPES = tuple | dict | set | list | int | float | bool | str | None
 
 class DocumentPublisher:
     """Publishes documents to Elasticsearch."""
@@ -335,6 +336,13 @@ class DocumentPublisher:
                 LOGGER.warning(
                     "Not publishing keyless attribute from entity [%s].",
                     state.entity_id,
+                )
+                continue
+
+            if not isinstance(orig_value, ALLOWED_ATTRIBUTE_TYPES):
+                LOGGER.debug(
+                    "Not publishing attribute [%s] of disallowed type [%s] from entity [%s].",
+                    key, type(orig_value), state.entity_id
                 )
                 continue
 

--- a/tests/test_es_doc_publisher.py
+++ b/tests/test_es_doc_publisher.py
@@ -197,6 +197,11 @@ async def test_attribute_publishing(hass, es_aioclient_mock: AiohttpClientMocker
 
     assert publisher.queue_size() == 0
 
+    class CustomAttributeClass:
+        def __init__(self) -> None:
+            self.field = "This class should be skipped, as it cannot be serialized."
+            pass
+
     hass.states.async_set("counter.test_1", "3", {
         "string": "abc123",
         "int": 123,
@@ -208,8 +213,11 @@ async def test_attribute_publishing(hass, es_aioclient_mock: AiohttpClientMocker
         },
         "list": [1,2,3,4],
         "set": {5,5},
+        "none": None,
         # Keyless entry should be excluded from output
-        "": "Keyless entry"
+        "": "Keyless entry",
+        # Custom classes should be excluded from output
+        "naughty": CustomAttributeClass(),
     })
     await hass.async_block_till_done()
 
@@ -240,7 +248,8 @@ async def test_attribute_publishing(hass, es_aioclient_mock: AiohttpClientMocker
                 "float": 123.456,
             }),
             "list": [1,2,3,4],
-            "set": [5] # set should be converted to a list
+            "set": [5], # set should be converted to a list,
+            "none": None
         }
     }]
 


### PR DESCRIPTION
Resolves https://github.com/legrego/homeassistant-elasticsearch/issues/179

Introduces a set of allowed attribute types to the document publisher. This component will only publish attribute values that are easily serialized.

Custom classes, for example, do not fall into this category, and will cause document publishing to fail. We could call `json.dumps` or similar on these classes, but at this point I do not believe the extra overhead of this operation is worth it. I'm willibng to revisit this decision in the future if needed.