### PR TITLE
Add missing entity.name mapping

### DIFF
--- a/custom_components/elasticsearch/index_mapping.json
+++ b/custom_components/elasticsearch/index_mapping.json
@@ -79,6 +79,9 @@
             "domain": {
               "type": "keyword"
             },
+            "name": {
+              "type": "keyword"
+            },
             "attributes": {
               "type": "object",
               "dynamic": true


### PR DESCRIPTION
Add missing `entity.name` mapping after 30c5e171f02ee7930e7e740188c73ddaee0fb17d, causing error like
```
{'index': {'_index': 'hass-events-v4_2-000001', '_id': '9MiD7osBpGp2PpLK0I_D', 'status': 400, 'error': {'type': 'strict_dynamic_mapping_exception', 'reason': '[ 1: 1247 ] mapping set to strict, dynamic introduction of [name] within [hass.entity] is not allowed'
```
