### PR TITLE
Gracefully handle internet/cluster connection errors

### DIFF
--- a/custom_components/elasticsearch/es_gateway.py
+++ b/custom_components/elasticsearch/es_gateway.py
@@ -130,14 +130,6 @@ class ElasticsearchGateway:
                 if self._connection_monitor_active:
                     await asyncio.sleep(1)
 
-    async def async_test_connection(self):
-        """Perform basic connection test."""
-        try:
-            await self.es_version.async_refresh()
-            return True
-        except Exception:
-            return False
-
     def _create_es_client(self):
         """Construct an instance of the Elasticsearch client."""
         from elasticsearch7._async.client import AsyncElasticsearch

--- a/custom_components/elasticsearch/es_gateway.py
+++ b/custom_components/elasticsearch/es_gateway.py
@@ -1,4 +1,7 @@
 """Encapsulates Elasticsearch operations."""
+import asyncio
+import time
+
 from homeassistant.const import (
     CONF_API_KEY,
     CONF_PASSWORD,
@@ -34,6 +37,10 @@ class ElasticsearchGateway:
         self.client = None
         self.es_version = None
 
+        self._connection_monitor_ref = None
+        self._active_connection_error = False
+        self._connection_monitor_active = False
+
     async def async_init(self):
         """I/O bound init."""
 
@@ -52,17 +59,84 @@ class ElasticsearchGateway:
                 self.es_version.to_string(),
             )
             raise UnsupportedVersion()
+
+        self._start_connection_monitor_task()
+
         LOGGER.debug("Gateway initialized")
 
     async def async_stop_gateway(self):
         """Stop the ES Gateway."""
+        LOGGER.debug("Stopping ES Gateway")
+
+        self._connection_monitor_active = False
+        self._active_connection_error = False
+        if self._connection_monitor_ref is not None:
+            self._connection_monitor_ref.cancel()
+            self._connection_monitor_ref = None
+
         if self.client:
             await self.client.close()
             self.client = None
 
+        LOGGER.debug("ES Gateway stopped")
+
     def get_client(self):
         """Return the underlying ES Client."""
         return self.client
+
+    @property
+    def active_connection_error(self):
+        """Returns if there is a known connection error."""
+        return self._active_connection_error
+
+    def notify_of_connection_error(self):
+        """Notify the gateway of a connection error."""
+        self._active_connection_error = True
+
+    def _start_connection_monitor_task(self):
+        """Initialize connection monitor task."""
+        LOGGER.debug("Starting connection monitor")
+        self._connection_monitor_ref = asyncio.ensure_future(self._connection_monitor_task())
+        self._connection_monitor_active = True
+
+    async def _connection_monitor_task(self):
+        from elasticsearch7 import TransportError
+        next_test = time.monotonic() + 30
+        while self._connection_monitor_active:
+            try:
+                can_test = next_test <= time.monotonic()
+                if can_test:
+                    LOGGER.debug("Starting connection test.")
+                    next_test = time.monotonic() + 30
+                    had_error = self._active_connection_error
+
+                    await self.client.info()
+
+                    self._active_connection_error = False
+                    LOGGER.debug("Finished connection test.")
+
+                    if had_error:
+                        LOGGER.info("Connection to [%s] has been reestablished. Operations will resume.")
+            except TransportError as transport_err:
+                LOGGER.debug("Finished connection test with TransportError")
+                ignorable_error = isinstance(transport_err.status_code, int) and transport_err.status_code <= 403
+                # Do not spam the logs with connection errors if we already know there is a problem.
+                if not ignorable_error and not self.active_connection_error:
+                    LOGGER.exception("Connection error. Operations will be paused until connection is reestablished. %s", transport_err)
+                    self._active_connection_error = True
+            except Exception as err:
+                LOGGER.exception("Error during connection monitoring task %s", err)
+            finally:
+                if self._connection_monitor_active:
+                    await asyncio.sleep(1)
+
+    async def async_test_connection(self):
+        """Perform basic connection test."""
+        try:
+            await self.es_version.async_refresh()
+            return True
+        except Exception:
+            return False
 
     def _create_es_client(self):
         """Construct an instance of the Elasticsearch client."""

--- a/tests/test_es_doc_publisher.py
+++ b/tests/test_es_doc_publisher.py
@@ -100,6 +100,8 @@ async def test_publish_state_change(hass, es_aioclient_mock: AiohttpClientMocker
 
     assert diff(request.data, _build_expected_payload(events)) == {}
 
+    await gateway.async_stop_gateway()
+
 @pytest.mark.asyncio
 async def test_entity_detail_publishing(hass, es_aioclient_mock: AiohttpClientMocker, mock_config_entry: mock_config_entry):
     """Test entity details are captured correctly."""
@@ -168,7 +170,7 @@ async def test_entity_detail_publishing(hass, es_aioclient_mock: AiohttpClientMo
     payload = bulk_requests[0].data
 
     assert diff(_build_expected_payload(events, include_entity_details=True, device_id=device.id, entity_name=entity_name), payload) == {}
-
+    await gateway.async_stop_gateway()
 
 @pytest.mark.asyncio
 async def test_attribute_publishing(hass, es_aioclient_mock: AiohttpClientMocker):
@@ -259,6 +261,7 @@ async def test_attribute_publishing(hass, es_aioclient_mock: AiohttpClientMocker
     }]
 
     assert diff(request.data, _build_expected_payload(events)) == {}
+    await gateway.async_stop_gateway()
 
 @pytest.mark.asyncio
 async def test_include_exclude_publishing_mode_all(hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker):
@@ -374,6 +377,7 @@ async def test_include_exclude_publishing_mode_all(hass: HomeAssistant, es_aiocl
     }]
 
     assert diff(request.data, _build_expected_payload(events)) == {}
+    await gateway.async_stop_gateway()
 
 @pytest.mark.asyncio
 async def test_include_exclude_publishing_mode_any(hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker):
@@ -462,6 +466,7 @@ async def test_include_exclude_publishing_mode_any(hass: HomeAssistant, es_aiocl
     }]
 
     assert diff(request.data, _build_expected_payload(events)) == {}
+    await gateway.async_stop_gateway()
 
 
 @pytest.mark.asyncio
@@ -549,6 +554,7 @@ async def test_publish_modes(hass: HomeAssistant, es_aioclient_mock: AiohttpClie
     payload = bulk_requests[0].data
 
     assert diff(_build_expected_payload(events), payload) == {}
+    await gateway.async_stop_gateway()
 
 def _build_expected_payload(events: list, include_entity_details = False, device_id = None, entity_name = None):
     def event_to_payload(event):


### PR DESCRIPTION
Resolves #195 

Implements a recurring connection check, and records the failure once in the HA logs. Another message is recorded when the connection is re-established.

The doc publisher will not attempt to publish during an active connection error.