### PR TITLE
Fix HACS homeassistant version

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
   "name": "Elasticsearch",
   "render_readme": true,
-  "homeassistant": "2022.4"
+  "homeassistant": "2023.11"
 }


### PR DESCRIPTION
Bump to `2023.11`