### PR TITLE
Drop `services.yaml`

### DIFF
--- a/custom_components/elasticsearch/services.yaml
+++ b/custom_components/elasticsearch/services.yaml
@@ -1,3 +1,0 @@
-publish_events:
-  name: Publish queued events
-  description: Publishes all queued events to Elasticsearch.


### PR DESCRIPTION
Drops the unused `services.yaml` file from the project.