### PR TITLE
Support self signed certificates

### DIFF
--- a/custom_components/elasticsearch/errors.py
+++ b/custom_components/elasticsearch/errors.py
@@ -22,6 +22,10 @@ class CannotConnect(ElasticException):
     """Unable to connect to the cluster."""
 
 
+class ClientError(ElasticException):
+    """Connected with a Client Error."""
+
+
 class UntrustedCertificate(ElasticException):
     """Connected with untrusted certificate."""
 
@@ -51,6 +55,9 @@ def convert_es_error(msg, err):
             err.info, aiohttp.client_exceptions.ClientConnectorCertificateError
         ):
             return UntrustedCertificate(msg, err)
+
+        if isinstance(err.info, aiohttp.client_exceptions.ClientConnectorError):
+            return ClientError(msg, err)
         return CannotConnect(msg, err)
 
     if isinstance(err, AuthenticationException):


### PR DESCRIPTION
Fixes: https://github.com/legrego/homeassistant-elasticsearch/issues/245

When we get a ClientConnectionError retry without SSL, if that works then present the error back as an untrusted_connection error and let the user have the option to bypass SSL validation