### PR TITLE
Update entity attributes to respect ECS

### DIFF
--- a/custom_components/elasticsearch/es_doc_creator.py
+++ b/custom_components/elasticsearch/es_doc_creator.py
@@ -115,8 +115,6 @@ class DocumentCreator:
                 )
                 continue
 
-            # so we replace them with an "_" instead.
-            # https://github.com/legrego/homeassistant-elasticsearch/issues/92
             key = self.normalize_attribute_name(orig_key)
             value = orig_value
 
@@ -142,6 +140,13 @@ class DocumentCreator:
             else:
                 should_serialize = isinstance(value, dict)
 
+            if key in attributes:
+                LOGGER.warning(
+                    "Attribute [%s] shares a key [%s] with another attribute for entity [%s]. Discarding previous attribute value.",
+                    orig_key,
+                    key,
+                    state.entity_id,
+                )
             attributes[key] = (
                 self._serializer.dumps(value) if should_serialize else value
             )
@@ -365,6 +370,8 @@ class DocumentCreator:
 
         # Replace all non-word characters with an underscore
         replaced_string = re.sub(r"[\W]+", "_", normalized_string)
+        # Remove leading and trailing underscores
+        replaced_string = re.sub(r"^_+|_+$", "", replaced_string)
 
         return replaced_string.lower()
 

--- a/custom_components/elasticsearch/es_doc_publisher.py
+++ b/custom_components/elasticsearch/es_doc_publisher.py
@@ -4,12 +4,12 @@ import time
 from datetime import datetime
 from queue import Queue
 
-from custom_components.elasticsearch.errors import ElasticException
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_CLOSE, EVENT_STATE_CHANGED
 from homeassistant.core import HomeAssistant, State, callback
 from homeassistant.helpers.typing import EventType
 
+from custom_components.elasticsearch.errors import ElasticException
 from custom_components.elasticsearch.es_doc_creator import DocumentCreator
 from custom_components.elasticsearch.es_gateway import ElasticsearchGateway
 from custom_components.elasticsearch.es_index_manager import IndexManager

--- a/tests/test_es_doc_creator.py
+++ b/tests/test_es_doc_creator.py
@@ -346,7 +346,9 @@ async def test_state_to_attributes(
         "list": [1, 2, 3, 4],
         "set": {5, 5},
         "none": None,
-        "Non ECS-Compliant    Attribute.ñame! 😀": True,
+        "Collision Test": "first value",
+        "collision_test": "second value",
+        "*_Non ECS-Compliant    Attribute.ñame! 😀": True,
         # Keyless entry should be excluded from output
         "": "Key is empty, and should be excluded",
         # Custom classes should be excluded from output
@@ -367,7 +369,8 @@ async def test_state_to_attributes(
         "int": 123,
         "list": [1, 2, 3, 4],
         "none": None,
-        "non_ecs_compliant_attribute_name_": True,
+        "collision_test": "second value",
+        "non_ecs_compliant_attribute_name": True,
         "set": [5],
         "string": "abc123",
     }

--- a/tests/test_es_doc_creator.py
+++ b/tests/test_es_doc_creator.py
@@ -346,6 +346,7 @@ async def test_state_to_attributes(
         "list": [1, 2, 3, 4],
         "set": {5, 5},
         "none": None,
+        "Non ECS-Compliant    Attribute.ñame! 😀": True,
         # Keyless entry should be excluded from output
         "": "Key is empty, and should be excluded",
         # Custom classes should be excluded from output
@@ -366,6 +367,7 @@ async def test_state_to_attributes(
         "int": 123,
         "list": [1, 2, 3, 4],
         "none": None,
+        "non_ecs_compliant_attribute_name_": True,
         "set": [5],
         "string": "abc123",
     }


### PR DESCRIPTION
Resolves #250.

Entity attributes should be published with ECS-compliant names. No upper-case, whitespace, or special characters should be permitted.

https://www.elastic.co/guide/en/ecs/current/ecs-guidelines.html#_guidelines_for_field_names