### PR TITLE
Remove deprecated usage of type helpers

### DIFF
--- a/custom_components/elasticsearch/__init__.py
+++ b/custom_components/elasticsearch/__init__.py
@@ -17,8 +17,8 @@ from homeassistant.const import (
     CONF_USERNAME,
     CONF_VERIFY_SSL,
 )
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
-from homeassistant.helpers.typing import HomeAssistantType
 
 from .const import (
     CONF_EXCLUDED_DOMAINS,
@@ -88,7 +88,7 @@ CONFIG_SCHEMA = vol.Schema(
 )
 
 
-async def async_setup(hass: HomeAssistantType, config):
+async def async_setup(hass: HomeAssistant, config):
     """Set up Elasticsearch integration via legacy yml-based setup."""
     if DOMAIN not in config:
         return True
@@ -110,7 +110,7 @@ async def async_setup(hass: HomeAssistantType, config):
     return True
 
 
-async def async_migrate_entry(hass: HomeAssistantType, config_entry: ConfigEntry):  # pylint: disable=unused-argument
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry):  # pylint: disable=unused-argument
     """Migrate old entry."""
 
     latest_version = ElasticFlowHandler.VERSION
@@ -129,7 +129,7 @@ async def async_migrate_entry(hass: HomeAssistantType, config_entry: ConfigEntry
     )
 
 
-async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
+async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Set up integration via config flow."""
 
     LOGGER.debug("Setting up integration")
@@ -138,7 +138,7 @@ async def async_setup_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
     return init
 
 
-async def async_unload_entry(hass: HomeAssistantType, config_entry: ConfigEntry):
+async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry):
     """Teardown integration."""
     existing_instance = hass.data.get(DOMAIN)
     if isinstance(existing_instance, ElasticIntegration):
@@ -148,15 +148,13 @@ async def async_unload_entry(hass: HomeAssistantType, config_entry: ConfigEntry)
     return True
 
 
-async def async_config_entry_updated(
-    hass: HomeAssistantType, config_entry: ConfigEntry
-):
+async def async_config_entry_updated(hass: HomeAssistant, config_entry: ConfigEntry):
     """Respond to config changes."""
     LOGGER.debug("Configuration change detected")
     return await _async_init_integration(hass, config_entry)
 
 
-async def _async_init_integration(hass: HomeAssistantType, config_entry: ConfigEntry):
+async def _async_init_integration(hass: HomeAssistant, config_entry: ConfigEntry):
     """Initialize integration."""
     await async_unload_entry(hass, config_entry)
 

--- a/custom_components/elasticsearch/es_integration.py
+++ b/custom_components/elasticsearch/es_integration.py
@@ -1,7 +1,7 @@
 """Support for sending event data to an Elasticsearch cluster."""
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 
 from custom_components.elasticsearch.errors import convert_es_error
 from custom_components.elasticsearch.es_privilege_check import ESPrivilegeCheck
@@ -15,7 +15,7 @@ from .es_index_manager import IndexManager
 class ElasticIntegration:
     """Integration for publishing entity state change events to Elasticsearch."""
 
-    def __init__(self, hass: HomeAssistantType, config_entry: ConfigEntry):
+    def __init__(self, hass: HomeAssistant, config_entry: ConfigEntry):
         """Integration initialization."""
 
         self.hass = hass

--- a/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[Test_Name-test_name].json
+++ b/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[Test_Name-test_name].json
@@ -1,4 +1,0 @@
-{
-  "dataset": "test_name",
-  "sanitized_dataset": "test_name"
-}

--- a/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[Test_Name-test_name].json
+++ b/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[Test_Name-test_name].json
@@ -1,4 +1,4 @@
 {
-  "dataset": "Test_Name",
+  "dataset": "test_name",
   "sanitized_dataset": "test_name"
 }

--- a/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[Test_Name_2-test_name_2].json
+++ b/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[Test_Name_2-test_name_2].json
@@ -1,0 +1,4 @@
+{
+  "dataset": "Test_Name_2",
+  "sanitized_dataset": "test_name_2"
+}

--- a/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[a_test_name-a_test_name].json
+++ b/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[a_test_name-a_test_name].json
@@ -1,0 +1,4 @@
+{
+  "dataset": "a_test_name",
+  "sanitized_dataset": "a_test_name"
+}

--- a/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[test_name-test_name].json
+++ b/tests/__snapshots__/test_es_doc_publisher/Test_Unit_Tests.test_sanitize_datastream_name[test_name-test_name].json
@@ -1,4 +1,0 @@
-{
-  "dataset": "test_name",
-  "sanitized_dataset": "test_name"
-}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,8 +22,7 @@ from unittest import mock
 from unittest.mock import patch
 
 import pytest
-from homeassistant.core import State
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant, State
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 from pytest_socket import enable_socket, socket_allow_hosts
@@ -78,7 +77,7 @@ def skip_notifications_fixture():
 
 
 @pytest.fixture()
-def mock_config_entry(hass: HomeAssistantType) -> MockConfigEntry:
+def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
     """Create a mock config entry and add it to hass."""
     entry = MockConfigEntry(title=None)
     entry.add_to_hass(hass)
@@ -90,7 +89,7 @@ class MockEntityState(State):
 
     def __init__(
         self,
-        hass: HomeAssistantType,
+        hass: HomeAssistant,
         entity_id: str,
         state: str,
         attributes: map | None = None,
@@ -153,7 +152,7 @@ class MockEntityState(State):
         await self.hass.async_block_till_done()
 
 
-def mock_entity_state(hass: HomeAssistantType) -> MockEntityState:
+def mock_entity_state(hass: HomeAssistant) -> MockEntityState:
     """Mock an entity state in the state machine."""
 
     state = MockEntityState()

--- a/tests/test_entity_details.py
+++ b/tests/test_entity_details.py
@@ -2,8 +2,8 @@
 
 import pytest
 from homeassistant.components.counter import DOMAIN as COUNTER_DOMAIN
+from homeassistant.core import HomeAssistant
 from homeassistant.helpers import area_registry, device_registry, entity_registry
-from homeassistant.helpers.typing import HomeAssistantType
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -14,14 +14,15 @@ from custom_components.elasticsearch.entity_details import (
 
 
 @pytest.mark.asyncio
-async def test_missing_entity(hass: HomeAssistantType):
+async def test_missing_entity(hass: HomeAssistant):
     """Verify missing entity returns None."""
     instance = EntityDetails(hass)
 
     assert instance.async_get("unknown_entity_id") is None
 
+
 @pytest.mark.asyncio
-async def test_entity_without_device(hass: HomeAssistantType):
+async def test_entity_without_device(hass: HomeAssistant):
     """Entity without device returns details."""
     config = {COUNTER_DOMAIN: {"test_1": {}}}
     assert await async_setup_component(hass, COUNTER_DOMAIN, config)
@@ -42,8 +43,9 @@ async def test_entity_without_device(hass: HomeAssistantType):
     assert deets.device is None
     assert deets.device_area is None
 
+
 @pytest.mark.asyncio
-async def test_entity_with_area(hass: HomeAssistantType):
+async def test_entity_with_area(hass: HomeAssistant):
     """Entity without device returns details."""
     area = area_registry.async_get(hass).async_create("mock")
 
@@ -69,8 +71,11 @@ async def test_entity_with_area(hass: HomeAssistantType):
     assert deets.device is None
     assert deets.device_area is None
 
+
 @pytest.mark.asyncio
-async def test_entity_with_device(hass: HomeAssistantType, mock_config_entry: MockConfigEntry):
+async def test_entity_with_device(
+    hass: HomeAssistant, mock_config_entry: MockConfigEntry
+):
     """Entity with device returns details."""
     entity_area = area_registry.async_get(hass).async_create("entity area")
     device_area = area_registry.async_get(hass).async_create("device area")
@@ -90,7 +95,9 @@ async def test_entity_with_device(hass: HomeAssistantType, mock_config_entry: Mo
     config = {COUNTER_DOMAIN: {"test_1": {}}}
     assert await async_setup_component(hass, COUNTER_DOMAIN, config)
     entity_id = "counter.test_1"
-    entity_registry.async_get(hass).async_update_entity(entity_id, area_id=entity_area.id, device_id=entry.id)
+    entity_registry.async_get(hass).async_update_entity(
+        entity_id, area_id=entity_area.id, device_id=entry.id
+    )
 
     state = hass.states.get(entity_id)
     assert int(state.state) == 0

--- a/tests/test_es_doc_publisher.py
+++ b/tests/test_es_doc_publisher.py
@@ -238,7 +238,7 @@ class Test_Unit_Tests:
     @pytest.mark.parametrize(
         "case,expected",
         [
-            ("test_name", "test_name"),
+            ("a_test_name", "a_test_name"),
             ("test-name", "test-name"),
             ("test_name_1", "test_name_1"),
             ("-test_name", "test_name"),

--- a/tests/test_es_doc_publisher.py
+++ b/tests/test_es_doc_publisher.py
@@ -244,7 +244,7 @@ class Test_Unit_Tests:
             ("-test_name", "test_name"),
             ("test/name", "testname"),
             ("test? name", "test_name"),
-            ("Test_Name", "test_name"),
+            ("Test_Name_2", "test_name_2"),
             ("test..name", "test..name"),
             (".,?/:*<>|#+", None),
             (".", None),

--- a/tests/test_es_privilege_check.py
+++ b/tests/test_es_privilege_check.py
@@ -6,7 +6,7 @@ from elasticsearch.const import (
     DOMAIN,
 )
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
@@ -24,7 +24,7 @@ from tests.test_util.es_startup_mocks import mock_es_initialization
 
 @pytest.mark.asyncio
 async def test_bad_connection(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Test graceful error handling."""
 
@@ -56,7 +56,7 @@ async def test_bad_connection(
 
 @pytest.mark.asyncio
 async def test_successful_modern_privilege_check(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Test successful privilege check."""
 
@@ -93,7 +93,7 @@ async def test_successful_modern_privilege_check(
 
 @pytest.mark.asyncio
 async def test_successful_modern_privilege_check_missing_index_privilege(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Test successful privilege check with missing index privileges."""
 
@@ -138,7 +138,7 @@ async def test_successful_modern_privilege_check_missing_index_privilege(
 
 @pytest.mark.asyncio
 async def test_successful_legacy_privilege_check(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Test successful privilege check."""
 
@@ -172,7 +172,7 @@ async def test_successful_legacy_privilege_check(
 
 @pytest.mark.asyncio
 async def test_successful_legacy_privilege_check_missing_index_privilege(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Test successful privilege check with missing index privileges."""
 
@@ -213,7 +213,7 @@ async def test_successful_legacy_privilege_check_missing_index_privilege(
 
 @pytest.mark.asyncio
 async def test_enforce_auth_failure(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Enforce should throw when missing privileges."""
 
@@ -249,7 +249,7 @@ async def test_enforce_auth_failure(
 
 @pytest.mark.asyncio
 async def test_enforce_auth_success(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Enforce should not throw when not missing privileges."""
 

--- a/tests/test_es_version.py
+++ b/tests/test_es_version.py
@@ -1,7 +1,7 @@
 """Test Elasticsearch Version."""
 
 import pytest
-from homeassistant.helpers.typing import HomeAssistantType
+from homeassistant.core import HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.test_util.aiohttp import AiohttpClientMocker
 
@@ -18,7 +18,7 @@ from tests.test_util.es_startup_mocks import mock_es_initialization
 
 @pytest.mark.asyncio
 async def test_serverless_true(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Verify serverless instances are detected."""
 
@@ -45,7 +45,7 @@ async def test_serverless_true(
 
 @pytest.mark.asyncio
 async def test_serverless_false(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Verify non-serverless instances are detected."""
 
@@ -74,7 +74,7 @@ async def test_serverless_false(
 
 @pytest.mark.asyncio
 async def test_fails_minimum_version(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Verify minimum version function works."""
 
@@ -102,7 +102,7 @@ async def test_fails_minimum_version(
 
 @pytest.mark.asyncio
 async def test_passes_minimum_version(
-    hass: HomeAssistantType, es_aioclient_mock: AiohttpClientMocker
+    hass: HomeAssistant, es_aioclient_mock: AiohttpClientMocker
 ):
     """Verify minimum version function works."""
 

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -4,14 +4,14 @@ from unittest import mock
 
 import pytest
 from homeassistant.const import __version__ as current_version
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.typing import HomeAssistantType
 
 from custom_components.elasticsearch.system_info import SystemInfo, SystemInfoResult
 
 
 @pytest.mark.asyncio
-async def test_success(hass: HomeAssistantType):
+async def test_success(hass: HomeAssistant):
     """Verify system info can be returned."""
     # Test adapted from:
     # https://github.com/home-assistant/core/blob/cec617cfbb86a57bebd80d1e1492dfe0ec7dc11d/tests/helpers/test_system_info.py#L23
@@ -26,8 +26,9 @@ async def test_success(hass: HomeAssistantType):
     assert result.hostname is not None
 
 
+
 @pytest.mark.asyncio
-async def test_error_handling(hass: HomeAssistantType):
+async def test_error_handling(hass: HomeAssistant):
     """Verify unexpected errors return empty object."""
 
     def mock_get_system_info():


### PR DESCRIPTION
https://developers.home-assistant.io/blog/2024/04/08/deprecated-backports-and-typing-aliases/

- `homeassistant.helpers.typing.EventType` has been replaced with `homeassistant.core.Event`. The former is deprecated and will be removed in a future release of Home Assistant.
- `homeassistant.helpers.typing.HomeAssistantType` has been replaced with `homeassistant.core.HomeAssistant`. The former is deprecated and will be removed in a future release of Home Assistant.

Relates #283 