### PR TITLE
[1.0] Update manifest.json to bump ES dependency

### DIFF
--- a/custom_components/elasticsearch/manifest.json
+++ b/custom_components/elasticsearch/manifest.json
@@ -14,7 +14,7 @@
   "issue_tracker": "https://github.com/legrego/homeassistant-elasticsearch/issues",
   "quality_scale": "gold",
   "requirements": [
-    "elasticsearch7==7.11.0"
+    "elasticsearch7==7.17.2"
   ],
   "version": "1.0.0"
 }


### PR DESCRIPTION
Fixes #427 

Missed updating the manifest means it's broken when installing via HACS