### PR TITLE
Include Filtering out state where value is zero

### DIFF
--- a/custom_components/elasticsearch/config_flow.py
+++ b/custom_components/elasticsearch/config_flow.py
@@ -31,6 +31,7 @@ from homeassistant.helpers.selector import (
 from custom_components.elasticsearch.const import (
     CONF_AUTHENTICATION_TYPE,
     CONF_CHANGE_DETECTION_TYPE,
+    CONF_FILTER_OUT_ZERO_FLOAT,
     CONF_EXCLUDE_TARGETS,
     CONF_INCLUDE_TARGETS,
     CONF_POLLING_FREQUENCY,
@@ -361,6 +362,7 @@ class ElasticOptionsFlowHandler(config_entries.OptionsFlow):
         CONF_PUBLISH_FREQUENCY: ONE_MINUTE,
         CONF_POLLING_FREQUENCY: ONE_MINUTE,
         CONF_CHANGE_DETECTION_TYPE: [StateChangeType.STATE.value, StateChangeType.ATTRIBUTE.value],
+        CONF_FILTER_OUT_ZERO_FLOAT: False,
         CONF_INCLUDE_TARGETS: False,
         CONF_EXCLUDE_TARGETS: False,
         CONF_TARGETS_TO_INCLUDE: {},
@@ -419,6 +421,10 @@ class ElasticOptionsFlowHandler(config_entries.OptionsFlow):
             "schema": CONF_TAGS,
             "default": from_options(CONF_TAGS),
         }
+        SCHEMA_FILTER_OUT_ZERO_FLOAT = {
+            "schema": CONF_FILTER_OUT_ZERO_FLOAT,
+            "default": from_options(CONF_FILTER_OUT_ZERO_FLOAT),
+        }
         SCHEMA_INCLUDE_TARGETS = {
             "schema": CONF_INCLUDE_TARGETS,
             "default": from_options(CONF_INCLUDE_TARGETS),
@@ -464,6 +470,9 @@ class ElasticOptionsFlowHandler(config_entries.OptionsFlow):
                 ),
                 vol.Optional(**SCHEMA_TAGS): SelectSelector(
                     SelectSelectorConfig(options=[], custom_value=True, multiple=True)
+                ),
+                vol.Optional(**SCHEMA_FILTER_OUT_ZERO_FLOAT): BooleanSelector(
+                    BooleanSelectorConfig(),
                 ),
                 vol.Optional(**SCHEMA_INCLUDE_TARGETS): BooleanSelector(
                     BooleanSelectorConfig(),

--- a/custom_components/elasticsearch/const.py
+++ b/custom_components/elasticsearch/const.py
@@ -17,6 +17,8 @@ CONF_CHANGE_DETECTION_TYPE: str = "change_detection_type"
 
 CONF_DEBUG_ATTRIBUTE_FILTERING: str = "debug_attribute_filtering"
 
+CONF_FILTER_OUT_ZERO_FLOAT = "filter_out_zero_float"
+
 CONF_INCLUDE_TARGETS: str = "include_targets"
 CONF_EXCLUDE_TARGETS: str = "exclude_targets"
 

--- a/custom_components/elasticsearch/es_integration.py
+++ b/custom_components/elasticsearch/es_integration.py
@@ -17,6 +17,7 @@ from homeassistant.const import (
 from custom_components.elasticsearch.const import (
     CONF_CHANGE_DETECTION_TYPE,
     CONF_DEBUG_ATTRIBUTE_FILTERING,
+    CONF_FILTER_OUT_ZERO_FLOAT,
     CONF_EXCLUDE_TARGETS,
     CONF_INCLUDE_TARGETS,
     CONF_POLLING_FREQUENCY,
@@ -125,6 +126,7 @@ class ElasticIntegration:
             change_detection_type=config_entry.options[CONF_CHANGE_DETECTION_TYPE],
             tags=config_entry.options[CONF_TAGS],
             debug_attribute_filtering=config_entry.options.get(CONF_DEBUG_ATTRIBUTE_FILTERING, False),
+            filter_out_zero_float=config_entry.options.get(CONF_FILTER_OUT_ZERO_FLOAT, False),
             include_targets=config_entry.options[CONF_INCLUDE_TARGETS],
             exclude_targets=config_entry.options[CONF_EXCLUDE_TARGETS],
             included_areas=config_entry.options[CONF_TARGETS_TO_INCLUDE].get("area_id", []),

--- a/custom_components/elasticsearch/translations/en.json
+++ b/custom_components/elasticsearch/translations/en.json
@@ -70,6 +70,7 @@
                     "polling_frequency": "Gather all entity states at this interval",
                     "change_detection_type": "Choose what types of entity changes to listen for and publish",
                     "tags": "Tags to apply to all published events",
+                    "filter_out_zero_float": "Exlude events where numerical value is 0",
                     "include_targets": "Toggle to only publish the set of targets below",
                     "exclude_targets": "Toggle to exclude publishing the set of targets below",
                     "targets_to_include": "Select the targets to include",


### PR DESCRIPTION
I'm using this custom component to track only power consumption :

![image](https://github.com/user-attachments/assets/0052b6fe-823a-4cd3-a95b-dc87ce52353a)

I can't use change based publishing events because watt computation will be wrong (ie. watt sensors are giving per hour consumption each time watt value is changing, due to this you can't retrieve properly the consumption) .

So had to disable pusblish on change and use polling every 10 sec to be sure at least power consumption higher than 10 sec is recording into elastic search. Then divide in kiban all values received by 60*(60/10) to be sure I'm computing the correct power consumption.

The issue with this approach is we receive a lot of events most of them being 0. As in a power consumption scenario I don't care about zero I need a way to ignore them.

