### PR TITLE
Remove manage_ilm from docs

### DIFF
--- a/docs/configure.md
+++ b/docs/configure.md
@@ -27,7 +27,6 @@ Use the following command to create an API Key for the Home Assistant component.
           "hass_writer": {
             "cluster": [
               "manage_index_templates",
-              "manage_ilm",
               "monitor"
             ],
             "indices": [
@@ -61,7 +60,6 @@ Use the following command to create an API Key for the Home Assistant component.
         "hass_writer": {
           "cluster": [
             "manage_index_templates",
-            "manage_ilm",
             "monitor"
           ],
           "indices": [


### PR DESCRIPTION
The docs did have manage_ilm in the docs when creating and API key but it seems the scripts itself do not use this anymore. This is relevant in the context of sending data to a Serverless instance where ILM does not exist.

Also see https://github.com/legrego/homeassistant-elasticsearch/issues/499

For reference, the error was:

```
{
  "error": {
    "root_cause": [
      {
        "type": "action_request_validation_exception",
        "reason": "Validation Failed: 1: cluster privilege [manage_ilm] exists but is not supported when running in serverless mode. a privilege must be one of the predefined cluster privilege names [manage_own_api_key,none,cancel_task,manage_index_templates,manage_logstash_pipelines,manage_search_application,manage_search_query_rules,manage_search_synonyms,monitor_connector,monitor_enrich,monitor_esql,monitor_inference,monitor_ml,monitor_transform,post_behavioral_analytics_event,read_pipeline,read_security,manage_api_key,manage_behavioral_analytics,manage_connector,manage_enrich,manage_inference,manage_ml,manage_transform,manage_ingest_pipelines,manage_pipeline,manage_security,monitor,manage,all];"
      }
    ],
    "type": "action_request_validation_exception",
    "reason": "Validation Failed: 1: cluster privilege [manage_ilm] exists but is not supported when running in serverless mode. a privilege must be one of the predefined cluster privilege names [manage_own_api_key,none,cancel_task,manage_index_templates,manage_logstash_pipelines,manage_search_application,manage_search_query_rules,manage_search_synonyms,monitor_connector,monitor_enrich,monitor_esql,monitor_inference,monitor_ml,monitor_transform,post_behavioral_analytics_event,read_pipeline,read_security,manage_api_key,manage_behavioral_analytics,manage_connector,manage_enrich,manage_inference,manage_ml,manage_transform,manage_ingest_pipelines,manage_pipeline,manage_security,monitor,manage,all];"
  },
  "status": 400
}
```