### PR TITLE
Potential fix for code scanning alert no. 11: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -1,4 +1,6 @@
 name: Pull actions
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/legrego/homeassistant-elasticsearch/security/code-scanning/11](https://github.com/legrego/homeassistant-elasticsearch/security/code-scanning/11)

To fix this problem, you should explicitly add a top-level `permissions` block to the workflow file (`.github/workflows/pull.yml`), right after the workflow name and before `on:`. This block should set the minimal necessary permission: `contents: read` is appropriate since the shown jobs only need to read the repo (checking out code and running tests/lints) and do not interact with issues, PRs, etc. This change does not interfere with existing workflow or functionality, and improves security posture.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
