### PR TITLE
fix: remove deprecated property

### DIFF
--- a/custom_components/elasticsearch/config_flow.py
+++ b/custom_components/elasticsearch/config_flow.py
@@ -370,7 +370,6 @@ class ElasticOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         """Initialize Elastic options flow."""
-        self.config_entry = config_entry
         self.options = dict(config_entry.options)
 
     async def async_step_init(self, user_input: dict | None = None) -> ConfigFlowResult:


### PR DESCRIPTION
Fixes https://github.com/legrego/homeassistant-elasticsearch/issues/540
Fixes https://github.com/legrego/homeassistant-elasticsearch/issues/421

`Detected that custom integration 'elasticsearch' sets option flow config_entry explicitly, which is deprecated at custom_components/elasticsearch/config_flow.py, line 373: self.config_entry = config_entry. This will stop working in Home Assistant 2025.12, please create a bug report at https://github.com/legrego/homeassistant-elasticsearch/issues`

This PR removes the property that is now handled at the parent class ([OptionsFlow](https://developers.home-assistant.io/docs/config_entries_options_flow_handler)).

All tests passed locally. 

cc: @legrego 