### PR TITLE
Fix datetime serialization in dict entity attributes

### DIFF
--- a/custom_components/elasticsearch/encoder.py
+++ b/custom_components/elasticsearch/encoder.py
@@ -19,8 +19,6 @@ def convert_set_to_list(data: Any) -> Any:
         return json.dumps(
             {key: convert_set_to_list(value) for key, value in data.items()},
             default=json_encoder_default,
-            ensure_ascii=False,
-            separators=(",", ":"),
         )
 
     if isinstance(data, list):

--- a/custom_components/elasticsearch/encoder.py
+++ b/custom_components/elasticsearch/encoder.py
@@ -4,10 +4,11 @@ import json
 from typing import Any
 
 from elasticsearch8.serializer import JSONSerializer
+from homeassistant.helpers.json import json_encoder_default
 
 
 def convert_set_to_list(data: Any) -> Any:
-    """Convert set to list."""
+    """Convert set to list and stringify dict attributes."""
 
     if isinstance(data, set):
         output = [convert_set_to_list(item) for item in data]
@@ -15,7 +16,12 @@ def convert_set_to_list(data: Any) -> Any:
         return output
 
     if isinstance(data, dict):
-        return json.dumps({key: convert_set_to_list(value) for key, value in data.items()})
+        return json.dumps(
+            {key: convert_set_to_list(value) for key, value in data.items()},
+            default=json_encoder_default,
+            ensure_ascii=False,
+            separators=(",", ":"),
+        )
 
     if isinstance(data, list):
         return [convert_set_to_list(item) for item in data]
@@ -48,4 +54,7 @@ class Encoder(json.JSONEncoder):
     def default(self, o: Any) -> Any:
         """Entry point."""
 
-        return super().default(convert_set_to_list(o))
+        try:
+            return json_encoder_default(o)
+        except TypeError:
+            return super().default(convert_set_to_list(o))

--- a/tests/test_encoder.py
+++ b/tests/test_encoder.py
@@ -1,0 +1,41 @@
+"""Tests for the encoder module."""
+
+import json
+from datetime import UTC, datetime
+
+from custom_components.elasticsearch.encoder import convert_set_to_list
+
+
+def test_convert_set_to_list_dict_with_datetime_values() -> None:
+    """Dict attributes with datetime values are stringified for Elasticsearch."""
+    start = datetime(2026, 6, 25, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 6, 25, 0, 30, tzinfo=UTC)
+    data = {"start": start, "end": end, "consumption": 0.687}
+
+    result = convert_set_to_list(data)
+
+    assert isinstance(result, str)
+    parsed = json.loads(result)
+    assert parsed["start"] == start.isoformat()
+    assert parsed["end"] == end.isoformat()
+    assert parsed["consumption"] == 0.687
+
+
+def test_convert_set_to_list_list_of_dicts_with_datetime_values() -> None:
+    """List attributes (e.g. Octopus Energy charges) serialize nested datetimes."""
+    start = datetime(2026, 6, 25, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 6, 25, 0, 30, tzinfo=UTC)
+    charges = [{"start": start, "end": end, "consumption": 0.5}]
+
+    result = convert_set_to_list(charges)
+
+    assert isinstance(result, list)
+    assert len(result) == 1
+    parsed = json.loads(result[0])
+    assert parsed["start"] == start.isoformat()
+    assert parsed["end"] == end.isoformat()
+
+
+def test_convert_set_to_list_set_sorted() -> None:
+    """Sets are converted to sorted lists."""
+    assert convert_set_to_list({3, 1, 2}) == [1, 2, 3]


### PR DESCRIPTION
## Summary

- Use `homeassistant.helpers.json.json_encoder_default` when stringifying dict entity attributes in `convert_set_to_list()`, so nested `datetime` values serialize to ISO-8601 strings instead of raising `TypeError`.
- Apply the same helper in `Encoder.default()` before falling back to existing set/list conversion.
- Add unit tests covering dict and list-of-dict attribute shapes (Octopus Energy `charges` pattern).

## Problem

PR #417 intentionally stringifies dict attributes via `json.dumps()` for Elasticsearch mapping compatibility. That path did not pass a `default` handler, so integrations that embed `datetime` objects inside dict/list attributes fail during publish.

Example (Octopus Energy `previous_accumulative_*` sensors):

```
TypeError: Object of type datetime is not JSON serializable
when serializing dict item 'start'
```

## Approach

Home Assistant already provides `json_encoder_default` for this exact purpose (datetime → ISO string, sets → lists, etc.). Using it here matches core HA JSON encoding behavior and avoids ad-hoc per-type handling in the integration.

This preserves the existing design of storing complex dict attributes as JSON strings in Elasticsearch.

## Test plan

- [x] `tests/test_encoder.py` — dict with datetime values, list of charge dicts, set sorting
- [ ] CI (`pull.yml`) — full test suite + lint


Made with [Cursor](https://cursor.com)