### PR TITLE
Fix crash on non-Hassio installs in SystemInfo

### DIFF
--- a/custom_components/elasticsearch/system_info.py
+++ b/custom_components/elasticsearch/system_info.py
@@ -39,8 +39,9 @@ class SystemInfo:
     def _get_host_info(self) -> dict | None:
         """Retrieve host information from HASS.
 
-        Only safe to call when running under Hassio, and even then the
+        Only expected to succeed when running under Hassio, and even then the
         Supervisor coordinator may not have completed its first refresh yet.
+        Errors are caught and swallowed so callers always get None instead.
         """
         try:
             return get_host_info(self._hass)

--- a/custom_components/elasticsearch/system_info.py
+++ b/custom_components/elasticsearch/system_info.py
@@ -37,20 +37,29 @@ class SystemInfo:
             raise ValueError(msg) from err
 
     def _get_host_info(self) -> dict | None:
-        """Retrieve host information from HASS."""
-        return get_host_info(self._hass)
+        """Retrieve host information from HASS.
+
+        Only safe to call when running under Hassio, and even then the
+        Supervisor coordinator may not have completed its first refresh yet.
+        """
+        try:
+            return get_host_info(self._hass)
+        except Exception:  # noqa: BLE001
+            LOGGER.debug("Unable to retrieve host info from the Hassio supervisor", exc_info=True)
+            return None
 
     async def async_get_system_info(self) -> SystemInfoResult | None:
         """Retrieve system information from HASS."""
         system_info = await self._get_system_info()
 
-        host_info = self._get_host_info()
-
         hostname = None
 
-        if host_info is not None and system_info["hassio"] is True:
-            hostname = host_info.get("hostname", None)
-        else:
+        if system_info["hassio"] is True:
+            host_info = self._get_host_info()
+            if host_info is not None:
+                hostname = host_info.get("hostname", None)
+
+        if hostname is None:
             hostname = socket.gethostname()
 
         return SystemInfoResult(

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -120,10 +120,10 @@ class Test_SystemInfo:
     async def test_get_host_info_swallows_errors(self, sys_info):
         """Verify errors raised by HASS's get_host_info are handled gracefully.
 
-        Regression test for #563: newer Home Assistant versions raise
-        HassioNotReadyError instead of returning None when host info isn't
-        available yet, e.g. on non-Hassio installs or before the Supervisor
-        coordinator's first refresh.
+        Regression test for #563: newer Home Assistant versions may raise
+        (e.g. HassioNotReadyError) instead of returning None when host info
+        isn't available yet, e.g. on non-Hassio installs or before the
+        Supervisor coordinator's first refresh.
         """
         with mock.patch(
             "custom_components.elasticsearch.system_info.get_host_info",

--- a/tests/test_system_info.py
+++ b/tests/test_system_info.py
@@ -62,8 +62,73 @@ class Test_SystemInfo:
             assert result.arch == "x86_64"
             assert result.hostname == "test-hostname"
 
+        # Regression test for #563: on non-Hassio installs, get_host_info() is
+        # unsafe to call (it raises HassioNotReadyError), so it must be skipped
+        # entirely rather than merely having its return value discarded.
+        sys_info._get_host_info.assert_not_called()
+
+    async def test_async_get_system_info_hassio(self, sys_info):
+        """Verify the hostname is sourced from host info when running under Hassio."""
+        sys_info._get_system_info = AsyncMock(
+            return_value={
+                "hassio": True,
+                "version": "1.0",
+                "arch": "x86_64",
+                "os_name": "Linux",
+                "os_version": "4.4.0-109-generic",
+                "hostname": None,
+            }
+        )
+        sys_info._get_host_info = Mock(return_value={"hostname": "hassio-hostname"})
+
+        result = await sys_info.async_get_system_info()
+
+        assert isinstance(result, SystemInfoResult)
+        assert result.hostname == "hassio-hostname"
+
+    async def test_async_get_system_info_hassio_not_ready(self, sys_info):
+        """Verify we fall back to the socket hostname if Hassio host info is unavailable.
+
+        Regression test for #563: the Supervisor coordinator can raise
+        HassioNotReadyError (e.g. before its first refresh completes), and that
+        must not crash integration setup.
+        """
+        sys_info._get_system_info = AsyncMock(
+            return_value={
+                "hassio": True,
+                "version": "1.0",
+                "arch": "x86_64",
+                "os_name": "Linux",
+                "os_version": "4.4.0-109-generic",
+                "hostname": None,
+            }
+        )
+        sys_info._get_host_info = Mock(return_value=None)
+
+        with mock.patch("socket.gethostname", return_value="test-hostname"):
+            result = await sys_info.async_get_system_info()
+
+            assert isinstance(result, SystemInfoResult)
+            assert result.hostname == "test-hostname"
+
     async def test_get_host_info(self, sys_info):
-        """Verify host information is returns an error on non-HASSio systems."""
+        """Verify host information returns None on non-HASSio systems."""
         host_info = sys_info._get_host_info()
+
+        assert host_info is None
+
+    async def test_get_host_info_swallows_errors(self, sys_info):
+        """Verify errors raised by HASS's get_host_info are handled gracefully.
+
+        Regression test for #563: newer Home Assistant versions raise
+        HassioNotReadyError instead of returning None when host info isn't
+        available yet, e.g. on non-Hassio installs or before the Supervisor
+        coordinator's first refresh.
+        """
+        with mock.patch(
+            "custom_components.elasticsearch.system_info.get_host_info",
+            side_effect=RuntimeError("HassioNotReadyError"),
+        ):
+            host_info = sys_info._get_host_info()
 
         assert host_info is None


### PR DESCRIPTION
## Summary
- `_get_host_info()` called HA's `get_host_info()` unconditionally, before checking whether the install is even running under Hassio, and without exception handling.
- Newer Home Assistant versions raise `HassioNotReadyError` instead of returning `None` when supervisor host data isn't available yet — this crashed integration setup on every non-Hassio install, and could also fire on Hassio installs before the supervisor coordinator's first refresh.
- The fix gates the call behind the existing `hassio` check (so it's skipped entirely on non-Hassio installs) and catches errors as a fallback, mirroring the exception handling already used in `_get_system_info()`.

Fixes #563

## Test plan
- [x] Added regression tests in `tests/test_system_info.py` covering: Hassio happy path, Hassio-not-ready fallback (simulated `HassioNotReadyError`), non-Hassio installs never calling `get_host_info`, and generic error-swallowing in `_get_host_info`.
- [x] Full test suite passes (365 passed).
- [x] `ruff check` / `ruff format --diff` clean.
- [x] `mypy` clean.
- [x] Manually reproduced the original crash by mocking `get_host_info` to raise, confirmed the fix resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)